### PR TITLE
feat: add TOML dependents

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [Installation](#installation)
 - [Configuration](#configuration)
   - [Projects](#projects)
+  - [Project dependents](#project-dependents)
   - [Example YAML configuration](#example-yaml-configuration)
   - [Example TOML configuration](#example-toml-configuration)
 - [Usage](#usage)
@@ -55,11 +56,32 @@ Applications are defined in the `projects` section of the configuration file.
 
 Each project is represented by a key-value pair, where the key is the name of the project and the value is a map with the following keys:
 
-| Key             | Description                                   | Allowed values                                                                                                                |
-| --------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `type`          | The type of the project.                      | `rust`, `node`, `helm`                                                                                                        |
-| `path`          | The path to the project.                      | Any valid directory path relative to the repository root. If omitted, the repository root is used instead.                    |
-| `manifest_path` | The path to the manifest file of the project. | Any valid file path relative to the project root. If omitted, the manifest file is assumed to be located at the project path. |
+| Key             | Description                                   | Allowed values                                                                                                                                                   |
+| --------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`          | The type of the project.                      | `rust`, `node`, `helm`                                                                                                                                           |
+| `path`          | The path to the project.                      | Any valid directory path relative to the repository root. If omitted, the repository root is used instead.                                                       |
+| `manifest_path` | The path to the manifest file of the project. | Any valid file path relative to the project root. If omitted, the manifest file is assumed to be located at the project path.                                    |
+| `dependents`    | The dependents of the project.                | A list of dependent files which should be updated when the project is released. For more information, see the [Project dependents](#project-dependents) section. |
+
+### Project dependents
+
+Projects can also have dependents. This is useful when you have a project that is used by other projects or files in the repository.
+
+When a project is released, its dependents will be updated with the new version number. Dependents are defined in the `dependents` section of the project configuration.
+
+Dependent settings can contain the following keys:
+
+| Key        | Description                                                | Allowed values                                                                                                              |
+| ---------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `type`     | The type of the dependent.                                 | `toml`                                                                                                                      |
+| `path`     | The path to the dependent file.                            | Any valid file path relative to the project root.                                                                           |
+| `selector` | The selector for the version number in the dependent file. | A selector for the version number in the dependent file. The format of the selector depends on the `type` of the dependent. |
+
+Selector formats for different dependent types:
+
+| Dependent type | Selector format                                                                                       |
+| -------------- | ----------------------------------------------------------------------------------------------------- |
+| `toml`         | Dot-separated path to the version number in the TOML file. For example: `dependencies.server.version` |
 
 ### Example YAML configuration
 
@@ -68,6 +90,10 @@ projects:
   server:
     type: rust
     path: server
+    dependents:
+      - type: toml
+        path: dependency.toml
+        selector: dependencies.server.version
   client:
     type: node
     path: client
@@ -83,6 +109,11 @@ projects:
 [projects.server]
 type = "rust"
 path = "server"
+
+[[projects.server.dependents]]
+type = "toml"
+path = "dependency.toml"
+selector = "dependencies.server.version"
 
 [projects.client]
 type = "node"

--- a/src/dependents/mod.rs
+++ b/src/dependents/mod.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use std::{fmt::Debug, path::PathBuf};
+
+use crate::{settings::DependentSettings, version::Version};
+use serde::Deserialize;
+
+mod toml;
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum DependentType {
+    Toml,
+}
+
+pub fn get_dependent(
+    dependent_settings: &DependentSettings,
+    repo_path: PathBuf,
+) -> Result<Box<dyn Dependent>> {
+    match dependent_settings.dependent_type {
+        DependentType::Toml => Ok(Box::new(toml::TomlDependent {
+            file_path: dependent_settings.dependent_path.clone(),
+            selector: dependent_settings
+                .selector
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("Selector is required for TOML dependent"))?,
+            repo_path: repo_path,
+        })),
+    }
+}
+
+pub trait Dependent: Debug {
+    fn update_version(&self, version: &Version) -> Result<()>;
+}

--- a/src/dependents/toml.rs
+++ b/src/dependents/toml.rs
@@ -1,0 +1,135 @@
+use anyhow::Result;
+use std::path::PathBuf;
+use toml_edit::{value, Document, Item};
+
+use crate::version::Version;
+
+use super::Dependent;
+
+/// General dependent for TOML files
+#[derive(Debug)]
+pub struct TomlDependent {
+    pub file_path: PathBuf,
+    pub selector: String,
+    pub repo_path: PathBuf,
+}
+
+impl Dependent for TomlDependent {
+    fn update_version(&self, version: &Version) -> Result<()> {
+        let file_content = crate::io::read_file(&self.file_path, &self.repo_path)?;
+        let new_file_content = update_toml(&file_content, version, &self.selector)?;
+        crate::io::write_file(&self.file_path, &self.repo_path, new_file_content.as_str())?;
+        Ok(())
+    }
+}
+
+/// Update a TOML file with a new version
+///
+/// Arguments:
+/// * `file_content` - The content of the TOML file
+/// * `version` - The new version
+/// * `selector` - The selector for the version field
+///
+/// The selector is a dot-separated list of keys to the version field.
+/// For example, if the version field is at the top level of the TOML
+/// file, the selector is "version". If the version field is in a
+/// table called "package", the selector is "package.version".
+/// If the version field is in a table called "package" and the
+/// table is in an array called "dependencies", the selector is
+/// "dependencies.package.version".
+///
+/// Arrays of tables are not supported.
+fn update_toml(file_content: &str, version: &Version, selector: &str) -> Result<String> {
+    let mut doc = file_content.parse::<Document>()?;
+    let keys = selector.split('.').collect::<Vec<_>>();
+    if keys.len() == 1 {
+        doc[&keys[0]] = value(version.to_string());
+    } else {
+        let mut item = &mut doc[keys[0]];
+        assert_not_array_of_tables(item)?;
+        for key in &keys[1..keys.len() - 1] {
+            item = &mut item[key];
+            assert_not_array_of_tables(item)?;
+        }
+        item[&keys[keys.len() - 1]] = value(version.to_string());
+    }
+    Ok(doc.to_string())
+}
+
+fn assert_not_array_of_tables(item: &Item) -> Result<()> {
+    if item.is_array_of_tables() {
+        return Err(anyhow::anyhow!(
+            "Array of tables not supported for TOML dependent"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::version::ToVersion;
+
+    use super::*;
+
+    #[test]
+    fn test_update_toml_top_level() {
+        let file_content = r#"version = "1.0.111""#;
+        let version = "1.0.112".to_version();
+        let selector = "version";
+        let new_file_content = update_toml(file_content, &version, selector).unwrap();
+        assert_eq!(
+            new_file_content,
+            "version = \"1.0.112\"\n" // Note toml_edit adds a newline
+        );
+    }
+
+    #[test]
+    fn test_update_toml_cargo_version() {
+        let file_content = r#"[dependencies]
+serde = { version = "1.0.195", features = ["derive"] }
+serde_json = "1.0.111"
+"#;
+        let version = "1.0.112".to_version();
+        let selector = "dependencies.serde_json";
+        let new_file_content = update_toml(file_content, &version, selector).unwrap();
+        assert_eq!(
+            new_file_content,
+            r#"[dependencies]
+serde = { version = "1.0.195", features = ["derive"] }
+serde_json = "1.0.112"
+"#
+        );
+    }
+
+    #[test]
+    fn test_update_toml_cargo_version_dict() {
+        let file_content = r#"[dependencies]
+serde = { version = "1.0.195", features = ["derive"] }
+serde_json = "1.0.111"
+"#;
+        let version = "1.0.196".to_version();
+        let selector = "dependencies.serde.version";
+        let new_file_content = update_toml(file_content, &version, selector).unwrap();
+        assert_eq!(
+            new_file_content,
+            r#"[dependencies]
+serde = { version = "1.0.196", features = ["derive"] }
+serde_json = "1.0.111"
+"#
+        );
+    }
+
+    #[test]
+    fn test_update_toml_array_of_tables() {
+        let file_content = r#"[[dependencies]]
+        "#;
+        let version = "1.0.196".to_version();
+        let selector = "dependencies.version";
+        let result = update_toml(file_content, &version, selector);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Array of tables not supported for TOML dependent"));
+    }
+}

--- a/src/projects/helm.rs
+++ b/src/projects/helm.rs
@@ -58,7 +58,7 @@ impl super::ProjectFile for HelmProject {
     fn update_version(
         &self,
         version_file_content: &str,
-        version_context: VersionContext,
+        version_context: &VersionContext,
     ) -> Result<String> {
         let value: Value = serde_yaml::from_str(version_file_content)?;
         let chart_version = value["version"]

--- a/src/projects/node.rs
+++ b/src/projects/node.rs
@@ -44,7 +44,7 @@ impl super::ProjectFile for NodeProject {
     fn update_version(
         &self,
         version_file_content: &str,
-        version_context: VersionContext,
+        version_context: &VersionContext,
     ) -> Result<String> {
         let pattern = Regex::new(&format!(r#""version"\s*:\s*"{}""#, version_context.version))?;
         let new_package_json = pattern.replace(

--- a/src/projects/rust.rs
+++ b/src/projects/rust.rs
@@ -63,7 +63,7 @@ impl super::ProjectFile for RustProject {
     fn update_version(
         &self,
         version_file_content: &str,
-        version_context: VersionContext,
+        version_context: &VersionContext,
     ) -> Result<String> {
         let mut doc = version_file_content.parse::<Document>()?;
         doc["package"]["version"] = value(version_context.next_version.to_string());

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::projects::ProjectType;
+use crate::{dependents::DependentType, projects::ProjectType};
 
 #[derive(Deserialize, Debug)]
 pub struct Settings {
@@ -20,6 +20,16 @@ pub struct ProjectSettings {
     #[serde(default, rename = "path")]
     pub project_path: PathBuf,
     pub manifest_path: Option<PathBuf>,
+    pub dependents: Option<Vec<DependentSettings>>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct DependentSettings {
+    #[serde(rename = "type")]
+    pub dependent_type: DependentType,
+    #[serde(default, rename = "path")]
+    pub dependent_path: PathBuf,
+    pub selector: Option<String>,
 }
 
 impl Settings {


### PR DESCRIPTION
Add `dependents` configuration for projects. This allows to update the version number in other files in the repository. The first implementation contains support for TOML files.