### PR TITLE
feat: add regex dependent

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,26 @@ Dependent settings can contain the following keys:
 
 | Key        | Description                                                | Allowed values                                                                                                              |
 | ---------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `type`     | The type of the dependent.                                 | `toml`                                                                                                                      |
+| `type`     | The type of the dependent.                                 | `regex`, `toml`                                                                                                             |
 | `path`     | The path to the dependent file.                            | Any valid file path relative to the project root.                                                                           |
 | `selector` | The selector for the version number in the dependent file. | A selector for the version number in the dependent file. The format of the selector depends on the `type` of the dependent. |
+| `replace`  | String to replace the selector match with.                 | A format string to replace the selector match with. The format of the string depends on the `type` of the dependent.        |
 
 Selector formats for different dependent types:
 
-| Dependent type | Selector format                                                                                       |
-| -------------- | ----------------------------------------------------------------------------------------------------- |
-| `toml`         | Dot-separated path to the version number in the TOML file. For example: `dependencies.server.version` |
+| Dependent type | Selector format                                                                                                                                                                                                 |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `regex`        | A regular expression that matches any text in the dependent file. Note that you will need to escape characters that would otherwise be interpreted by the YAML/TOML parsing. For example: `v\\d+\\.\\d+\\.\\d+` |
+| `toml`         | Dot-separated path to the version number in the TOML file. For example: `dependencies.server.version`                                                                                                           |
+
+Replace formats for different dependent types:
+
+| Dependent type | Replace format                                                                                     |
+| -------------- | -------------------------------------------------------------------------------------------------- |
+| `regex`        | A format string that replaces the matching text in the dependent file. For example: `v{{version}}` |
+| `toml`         | N/A                                                                                                |
+
+The `replace` string can contain the `{{version}}` placeholder, which will be replaced with the new version number when the project is released.
 
 ### Example YAML configuration
 
@@ -91,6 +102,10 @@ projects:
     type: rust
     path: server
     dependents:
+      - type: regex
+        path: client/package.json
+        selector: "\"server\": \".?\\d+\\.\\d+\\.\\d+\""
+        replace: '"server": "{{version}}"'
       - type: toml
         path: dependency.toml
         selector: dependencies.server.version
@@ -109,6 +124,12 @@ projects:
 [projects.server]
 type = "rust"
 path = "server"
+
+[[projects.server.dependents]]
+type = "regex"
+path = "client/package.json"
+selector = "\"server\": \".?\\d+\\.\\d+\\.\\d+\""
+replace = '"server": "{{version}}"'
 
 [[projects.server.dependents]]
 type = "toml"

--- a/src/dependents/mod.rs
+++ b/src/dependents/mod.rs
@@ -4,11 +4,13 @@ use std::{fmt::Debug, path::PathBuf};
 use crate::{settings::DependentSettings, version::Version};
 use serde::Deserialize;
 
+mod regex;
 mod toml;
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum DependentType {
+    Regex,
     Toml,
 }
 
@@ -17,6 +19,10 @@ pub fn get_dependent(
     repo_path: PathBuf,
 ) -> Result<Box<dyn Dependent>> {
     match dependent_settings.dependent_type {
+        DependentType::Regex => Ok(Box::new(regex::RegexDependent {
+            settings: dependent_settings.clone(),
+            repo_path: repo_path,
+        })),
         DependentType::Toml => Ok(Box::new(toml::TomlDependent {
             file_path: dependent_settings.dependent_path.clone(),
             selector: dependent_settings

--- a/src/dependents/regex.rs
+++ b/src/dependents/regex.rs
@@ -1,0 +1,103 @@
+use anyhow::Result;
+use regex::RegexBuilder;
+use std::path::PathBuf;
+
+use crate::{settings::DependentSettings, version::Version};
+
+use super::Dependent;
+
+#[derive(Debug)]
+pub struct RegexDependent {
+    pub settings: DependentSettings,
+    pub repo_path: PathBuf,
+}
+
+impl Dependent for RegexDependent {
+    fn update_version(&self, version: &Version) -> Result<()> {
+        let file_content = crate::io::read_file(&self.settings.dependent_path, &self.repo_path)?;
+        let new_file_content = update_regex(&file_content, version, &self.settings)?;
+        crate::io::write_file(
+            &self.settings.dependent_path,
+            &self.repo_path,
+            new_file_content.as_str(),
+        )?;
+        Ok(())
+    }
+}
+
+fn update_regex(
+    file_content: &str,
+    version: &Version,
+    settings: &DependentSettings,
+) -> Result<String> {
+    let selector = settings
+        .selector
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("Selector is required for regex dependent"))?;
+    let replace = &settings
+        .replace
+        .clone()
+        .unwrap_or(version.to_string())
+        .replace("{{version}}", &format!("{}", version));
+    let pattern = RegexBuilder::new(selector).multi_line(true).build()?;
+    let new_file_content = pattern.replace(&file_content, replace.as_str());
+    Ok(new_file_content.into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dependents::DependentType;
+    use crate::version::ToVersion;
+
+    #[test]
+    fn test_update_regex() {
+        let file_content = r#"version = "0.1.0""#;
+        let version = "0.2.0".to_version();
+        let settings = DependentSettings {
+            dependent_type: DependentType::Regex,
+            dependent_path: PathBuf::from("Cargo.toml"),
+            selector: Some(r#"(\d+\.\d+\.\d+)"#.to_string()),
+            replace: None,
+        };
+        let new_file_content = update_regex(file_content, &version, &settings).unwrap();
+        assert_eq!(new_file_content, r#"version = "0.2.0""#);
+    }
+
+    #[test]
+    fn test_update_regex_with_replace() {
+        let file_content = r#"version = "0.1.0""#;
+        let version = "0.2.0".to_version();
+        let settings = DependentSettings {
+            dependent_type: DependentType::Regex,
+            dependent_path: PathBuf::from("Cargo.toml"),
+            selector: Some(r#"version = "(.*)""#.to_string()),
+            replace: Some(r#"version = "{{version}}""#.to_string()),
+        };
+        let new_file_content = update_regex(file_content, &version, &settings).unwrap();
+        assert_eq!(new_file_content, r#"version = "0.2.0""#);
+    }
+
+    #[test]
+    fn test_update_regex_multi_line() {
+        let file_content = r#"
+[package]
+version = "0.1.0"
+"#;
+        let version = "0.2.0".to_version();
+        let settings = DependentSettings {
+            dependent_type: DependentType::Regex,
+            dependent_path: PathBuf::from("Cargo.toml"),
+            selector: Some(r#"version = "(.*)""#.to_string()),
+            replace: Some(r#"version = "{{version}}""#.to_string()),
+        };
+        let new_file_content = update_regex(file_content, &version, &settings).unwrap();
+        assert_eq!(
+            new_file_content,
+            r#"
+[package]
+version = "0.2.0"
+"#
+        );
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -30,6 +30,7 @@ pub struct DependentSettings {
     #[serde(default, rename = "path")]
     pub dependent_path: PathBuf,
     pub selector: Option<String>,
+    pub replace: Option<String>,
 }
 
 impl Settings {


### PR DESCRIPTION
Add new dependent type `regex` which allows replacing regex matches with replacement strings in files.