### PR TITLE
Use libyaml-safer for YAML parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ chrono = "0.4.31"
 clap = { version = "4.4.16", features = ["derive"] }
 config = "0.13.4"
 git2 = "0.18.1"
+libyaml-safer = "0.1.1"
 log = "0.4.20"
 regex = "1.10.3"
 serde = { version = "1.0.195", features = ["derive"] }

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -1,4 +1,5 @@
 pub mod toml;
+pub mod yaml;
 
 /// Metadata for a value entry in an edit context
 pub struct LineContext {

--- a/src/edit/yaml.rs
+++ b/src/edit/yaml.rs
@@ -1,0 +1,178 @@
+use anyhow::Result;
+use libyaml_safer::{Document, Node, NodeData, NodePair, Parser};
+
+use super::LineContext;
+
+/// Query a YAML file for a value at a given selector
+pub fn query(file_content: &str, selector: &str) -> Result<LineContext> {
+    log::info!("Querying YAML file for selector: {}", selector);
+    let mut parser = Parser::new();
+    let mut data = file_content.as_bytes();
+    parser.set_input_string(&mut data);
+    let mut document = Document::load(&mut parser)?;
+    let keys = selector.split('.').collect::<Vec<_>>();
+    let value_node = get_value_node(&mut document, keys)?;
+    match value_node {
+        Node {
+            data: NodeData::Scalar { value, .. },
+            start_mark,
+            ..
+        } => Ok(LineContext {
+            line_number: start_mark.line as usize + 1,
+            value: value.to_string(),
+        }),
+        _ => Err(anyhow::anyhow!("Value is not a scalar")),
+    }
+}
+
+/// Get the value node for a given selector
+///
+/// This function traverses the YAML document, looking for the node that
+/// corresponds to the given selector.
+fn get_value_node<'a>(document: &'a mut Document, keys: Vec<&str>) -> Result<&'a Node> {
+    // Start at the root node
+    let mut current_node = document
+        .get_node(1)
+        .ok_or_else(|| anyhow::anyhow!("YAML document does not contain a root node"))?;
+    // Keep track of the keys we've processed so far for error messages
+    let mut processed_keys = Vec::new();
+    for key in keys {
+        processed_keys.push(key);
+        // Get the node pairs for the current mapping
+        let pairs = match &current_node.data {
+            NodeData::Mapping { pairs, .. } => pairs,
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Value for '{}' is not a mapping",
+                    processed_keys.join(".")
+                ))
+            }
+        };
+        // Find the pair that corresponds to the current key
+        if let Some(pair) = find_node_pair_by_key(&document, &pairs, key) {
+            current_node = document.get_node(pair.value).unwrap();
+        } else {
+            return Err(anyhow::anyhow!(
+                "Key '{}' not found or not scalar",
+                processed_keys.join(".")
+            ));
+        }
+    }
+    // Return the node for the final key, which should be a scalar
+    match current_node.data {
+        NodeData::Scalar { .. } => Ok(current_node),
+        _ => Err(anyhow::anyhow!(
+            "Value for '{}' is not a scalar",
+            processed_keys.join(".")
+        )),
+    }
+}
+
+/// Find a node pair by key
+///
+/// This function searches a list of node pairs for a pair that has a key with
+/// the given value. If a matching pair is found, it is returned. Otherwise, None
+/// is returned.
+fn find_node_pair_by_key<'a>(
+    document: &'a Document,
+    pairs: &'a Vec<NodePair>,
+    key: &'a str,
+) -> Option<&'a NodePair> {
+    pairs
+        .iter()
+        .find(|pair| match &document.get_node(pair.key).unwrap().data {
+            NodeData::Scalar { value, .. } => value == key,
+            _ => false,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_query() {
+        let file_content = r#"appVersion: "1.2.3""#;
+        let selector = "appVersion";
+        let result = query(file_content, selector).unwrap();
+        assert_eq!(result.value, "1.2.3");
+        assert_eq!(result.line_number, 1);
+    }
+
+    #[test]
+    fn test_query_nested() {
+        let file_content = r#"single_key: "single_value"
+test_key:
+  nested_key: "value"     
+dependencies:
+  serde: "1.0""#;
+        let selector = "dependencies.serde";
+        let result = query(file_content, selector).unwrap();
+        assert_eq!(result.value, "1.0");
+        assert_eq!(result.line_number, 5);
+    }
+
+    #[test]
+    fn test_query_not_found() {
+        let file_content = r#"appVersion: "1.2.3"
+                "#;
+        let selector = "not_found";
+        let result = query(file_content, selector);
+        match result {
+            Ok(_) => panic!("Expected an error"),
+            Err(e) => assert!(e.to_string().contains("Key 'not_found' not found")),
+        }
+    }
+
+    #[test]
+    fn test_query_nested_not_found() {
+        let file_content = r#"single_key: "single_value"
+test_key:
+    nested_key: "value"
+dependencies:
+    serde: "1.0""#;
+        let selector = "dependencies.not_found";
+        let result = query(file_content, selector);
+        match result {
+            Ok(_) => panic!("Expected an error"),
+            Err(e) => assert!(e
+                .to_string()
+                .contains("Key 'dependencies.not_found' not found")),
+        }
+    }
+
+    #[test]
+    fn test_query_nested_not_scalar() {
+        let file_content = r#"single_key: "single_value"
+test_key:
+    nested_key: "value"
+dependencies:
+    serde:
+        version: "1.0""#;
+        let selector = "dependencies.serde";
+        let result = query(file_content, selector);
+        match result {
+            Ok(_) => panic!("Expected an error"),
+            Err(e) => assert!(e
+                .to_string()
+                .contains("Value for 'dependencies.serde' is not a scalar")),
+        }
+    }
+
+    #[test]
+    fn test_query_nested_not_mapping() {
+        let file_content = r#"single_key: "single_value"
+test_key:
+    nested_key: "value"
+dependencies:
+    - serde"#;
+        let selector = "dependencies.serde";
+        let result = query(file_content, selector);
+        match result {
+            Ok(_) => panic!("Expected an error"),
+            Err(e) => assert!(e
+                .to_string()
+                .contains("Value for 'dependencies.serde' is not a mapping")),
+        }
+    }
+}

--- a/src/projects/helm.rs
+++ b/src/projects/helm.rs
@@ -1,6 +1,4 @@
 use anyhow::Result;
-use regex::RegexBuilder;
-use serde_yaml::Value;
 use std::path::PathBuf;
 
 use crate::{
@@ -29,30 +27,8 @@ impl super::ProjectFile for HelmProject {
     }
 
     fn version_context(&self, version_file_content: &str) -> Result<VersionContext> {
-        let value: Value = serde_yaml::from_str(version_file_content)?;
-        let version = value["appVersion"]
-            .as_str()
-            .ok_or(anyhow::anyhow!(
-                "Failed to parse version from Chart.yaml: {:?}",
-                self.base.settings.get_manifest_file_path()
-            ))?
-            .to_version();
-        let pattern = regex::Regex::new(&format!(r#"^appVersion:\s*"?{}"?"#, version))?;
-        let line_number = version_file_content
-            .lines()
-            .enumerate()
-            .find(|(_, line)| pattern.is_match(line))
-            .map(|(line_number, _)| line_number + 1)
-            .ok_or(anyhow::anyhow!(
-                "Failed to find version in Chart.yaml: {:?}",
-                self.base.settings.get_manifest_file_path()
-            ))?;
-        log::info!(
-            "Found version {} in Chart.yaml at line {}",
-            version,
-            line_number
-        );
-        Ok(VersionContext::new(version, line_number))
+        let line_context = crate::edit::yaml::query(version_file_content, "appVersion")?;
+        Ok(VersionContext::from_line_context(line_context))
     }
 
     fn update_version(
@@ -60,32 +36,79 @@ impl super::ProjectFile for HelmProject {
         version_file_content: &str,
         version_context: &VersionContext,
     ) -> Result<String> {
-        let value: Value = serde_yaml::from_str(version_file_content)?;
-        let chart_version = value["version"]
-            .as_str()
-            .ok_or(anyhow::anyhow!(
-                "Failed to parse version from Chart.yaml: {:?}",
-                self.base.settings.get_manifest_file_path()
-            ))?
-            .to_version();
-        let app_version_pattern = RegexBuilder::new(&format!(
-            r#"^appVersion:\s*"?{}"?"#,
-            version_context.version
-        ))
-        .multi_line(true)
-        .build()?;
-        let chart_version_pattern =
-            RegexBuilder::new(&format!(r#"^version:\s*"?{}"?"#, chart_version))
-                .multi_line(true)
-                .build()?;
-        let result = app_version_pattern.replace(
-            &version_file_content,
-            format!(r#"appVersion: "{}""#, version_context.next_version),
+        let next_chart_version = crate::edit::yaml::query(version_file_content, "version")?
+            .value
+            .to_version()
+            .bump_patch()
+            .to_string();
+        let next_app_version = version_context.next_version.to_string();
+        let mut new_content =
+            crate::edit::yaml::edit(version_file_content, "version", &next_chart_version)?;
+        new_content = crate::edit::yaml::edit(&new_content, "appVersion", &next_app_version)?;
+        Ok(new_content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::projects::ProjectFile;
+    use crate::version::ToVersion;
+
+    #[test]
+    fn test_version_context() {
+        let project = HelmProject::new(
+            ProjectSettings {
+                project_type: crate::projects::ProjectType::Helm,
+                project_path: PathBuf::new(),
+                manifest_path: Some("Chart.yaml".into()),
+                selector: None,
+                dependents: None,
+            },
+            PathBuf::new(),
         );
-        let result = chart_version_pattern.replace(
-            &result,
-            format!(r#"version: {}"#, chart_version.bump_patch()),
+        let version_file_content = r#"apiVersion: v2
+appVersion: "1.2.3"
+description: A Helm chart for Kubernetes
+name: test
+version: 0.1.0"#;
+        let result = project.version_context(version_file_content).unwrap();
+        assert_eq!(result.version, "1.2.3".to_version());
+        assert_eq!(result.line_number, 2);
+    }
+
+    #[test]
+    fn test_update_version() {
+        let project = HelmProject::new(
+            ProjectSettings {
+                project_type: crate::projects::ProjectType::Helm,
+                project_path: PathBuf::new(),
+                manifest_path: Some("Chart.yaml".into()),
+                selector: None,
+                dependents: None,
+            },
+            PathBuf::new(),
         );
-        Ok(result.into_owned())
+        let version_file_content = r#"apiVersion: v2
+description: A Helm chart for Kubernetes
+name: test
+appVersion: "1.2.3"
+version: 0.1.0"#;
+        let version_context = VersionContext {
+            version: "1.2.3".to_version(),
+            next_version: "1.2.4".to_version(),
+            line_number: 3,
+        };
+        let result = project
+            .update_version(version_file_content, &version_context)
+            .unwrap();
+        assert_eq!(
+            result,
+            r#"apiVersion: v2
+description: A Helm chart for Kubernetes
+name: test
+appVersion: "1.2.4"
+version: 0.1.1"#
+        );
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -2,8 +2,10 @@ use core::fmt;
 
 use chrono::Datelike;
 
+use crate::edit::LineContext;
+
 /// A version in the format of YY.MM.PATCH
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Version {
     pub major: u32,
     pub minor: u32,
@@ -77,6 +79,16 @@ impl VersionContext {
             version,
             next_version,
             line_number,
+        }
+    }
+
+    pub fn from_line_context(line_context: LineContext) -> Self {
+        let version = line_context.value.to_version();
+        let next_version = version.bump();
+        Self {
+            version,
+            next_version,
+            line_number: line_context.line_number,
         }
     }
 }


### PR DESCRIPTION
- Implement parsing logic using `libyaml-safer` as it lets us get the line number as well as the exact position of the version data.
- Use the new logic for the Helm type.