### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/jannekem/monoverse/compare/v0.1.3...v0.1.4) - 2024-03-17
+
+### Added
+- make logging verbosity configurable
+- add --force flag to release command
+
+### Other
+- mention force flag in README
+- add container instructions
+
 ## [0.1.3](https://github.com/jannekem/monoverse/compare/v0.1.2...v0.1.3) - 2024-03-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monoverse"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Janne Kemppainen"]
 description = "A CLI tool for managing version numbers in monorepos."


### PR DESCRIPTION
## 🤖 New release
* `monoverse`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/jannekem/monoverse/compare/v0.1.3...v0.1.4) - 2024-03-17

### Added
- make logging verbosity configurable
- add --force flag to release command

### Other
- mention force flag in README
- add container instructions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).