### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/jannekem/monoverse/compare/v0.1.6...v0.1.7) - 2024-09-10
+
+### Added
+
+- add versionfile project type
+
+### Other
+
+- add missing dependent type
+
 ## [0.1.6](https://github.com/jannekem/monoverse/compare/v0.1.5...v0.1.6) - 2024-05-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monoverse"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["Janne Kemppainen"]
 description = "A CLI tool for managing version numbers in monorepos."


### PR DESCRIPTION
## 🤖 New release
* `monoverse`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7](https://github.com/jannekem/monoverse/compare/v0.1.6...v0.1.7) - 2024-09-10

### Added

- add versionfile project type

### Other

- add missing dependent type
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).