### PR TITLE
feat(helm): add helm dependents and sequence selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Selector formats for project types that use the `selector` key:
 | Project type | Selector format                                                                           |
 | ------------ | ----------------------------------------------------------------------------------------- |
 | `toml`       | Dot-separated path to the version number in the TOML file. For example: `package.version` |
-| `yaml`       | Dot-separated path to the version number in the YAML file. For example: `package.version` |
+| `yaml`       | Dot-separated path, with optional sequence selectors. For example: `package.version` or `groups[name=app].dependencies[0].version` |
 
 Project types:
 
@@ -110,8 +110,8 @@ Dependent settings can contain the following keys:
 
 | Key        | Description                                                | Allowed values                                                                                                              |
 | ---------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `type`     | The type of the dependent.                                 | `regex`, `toml`, `yaml`                                                                                                     |
-| `path`     | The path to the dependent file.                            | Any valid file path relative to the project root.                                                                           |
+| `type`     | The type of the dependent.                                 | `regex`, `toml`, `yaml`, `helm`                                                                                              |
+| `path`     | The path to the dependent file.                            | Any valid file path relative to the project root. For `helm` dependents, use the chart directory.                           |
 | `selector` | The selector for the version number in the dependent file. | A selector for the version number in the dependent file. The format of the selector depends on the `type` of the dependent. |
 | `replace`  | String to replace the selector match with.                 | A format string to replace the selector match with. The format of the string depends on the `type` of the dependent.        |
 
@@ -121,7 +121,8 @@ Selector formats for different dependent types:
 | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `regex`        | A regular expression that matches any text in the dependent file. Note that you will need to escape characters that would otherwise be interpreted by the YAML/TOML parsing. For example: `v\\d+\\.\\d+\\.\\d+` |
 | `toml`         | Dot-separated path to the version number in the TOML file. For example: `dependencies.server.version`                                                                                                           |
-| `yaml`         | Dot-separated path to the version number in the YAML file. For example: `dependencies.server.version`                                                                                                           |
+| `yaml`         | Dot-separated path with optional sequence selectors. For example: `dependencies.server.version` or `groups[name=app].dependencies[name=common].version`                                                           |
+| `helm`         | Dot-separated path with optional sequence selectors. For example: `dependencies[name=common].version`                                                                                                           |
 
 Replace formats for different dependent types:
 
@@ -130,8 +131,11 @@ Replace formats for different dependent types:
 | `regex`        | A format string that replaces the matching text in the dependent file. Defaults to the new version string. For example: `v{{version}}` |
 | `toml`         | N/A                                                                                                                                    |
 | `yaml`         | N/A                                                                                                                                    |
+| `helm`         | N/A                                                                                                                                    |
 
 The `replace` string can contain the `{{version}}` placeholder, which will be replaced with the new version number when the project is released.
+
+For `helm` dependents, `monoverse` can run `helm dependency update` in the chart directory after updating `Chart.yaml`, which updates `Chart.lock` and may write `.tgz` archives under `charts/`. This is controlled by the `--helm-dependency-update` flag and requires Helm on `PATH`.
 
 ### Example YAML configuration
 
@@ -210,6 +214,7 @@ The following arguments are also available:
 - `-f`, `--force`: Force a release even if the project has no changes.
 - `--commit`: Commit the changes to the repository.
 - `--tag`: Create a new tag in the repository, requires `--commit`. By default, the tag format is `<project>-<version>`. It can be customized by configuring the `tag_prefix` key in the configuration file for each project.
+- `--helm-dependency-update`: Run `helm dependency update` for `helm` dependents after updating `Chart.yaml`.
 
 ### Next
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,6 +38,9 @@ pub struct Release {
     /// Create a tag
     #[clap(long, requires = "commit")]
     pub tag: bool,
+    /// Run `helm dependency update` for helm dependents
+    #[clap(long)]
+    pub helm_dependency_update: bool,
 }
 
 #[derive(Parser)]

--- a/src/dependents/helm.rs
+++ b/src/dependents/helm.rs
@@ -1,0 +1,89 @@
+use anyhow::{Context, Result};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use crate::{settings::DependentSettings, version::Version};
+
+use super::Dependent;
+
+#[derive(Debug)]
+pub struct HelmDependent {
+    pub settings: DependentSettings,
+    pub repo_path: PathBuf,
+}
+
+impl HelmDependent {
+    fn run_helm_dependency_update(&self, chart_dir: &Path) -> Result<()> {
+        let output = Command::new("helm")
+            .arg("dependency")
+            .arg("update")
+            .current_dir(chart_dir)
+            .output()
+            .with_context(|| {
+                format!(
+                    "Failed to run 'helm dependency update' in {}",
+                    chart_dir.display()
+                )
+            })?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!(
+                "helm dependency update failed: {}",
+                stderr.trim()
+            ));
+        }
+        Ok(())
+    }
+
+    fn collect_dependency_artifacts(&self, chart_dir: &Path) -> Result<Vec<PathBuf>> {
+        let chart_lock_path = chart_dir.join("Chart.lock");
+        let mut file_paths = Vec::new();
+        if self.repo_path.join(&chart_lock_path).exists() {
+            file_paths.push(chart_lock_path);
+        }
+        let charts_dir = chart_dir.join("charts");
+        let charts_dir_abs = self.repo_path.join(&charts_dir);
+        if charts_dir_abs.is_dir() {
+            fs::read_dir(&charts_dir_abs)?.try_for_each(|entry| -> Result<()> {
+                let path = entry?.path();
+                if path.extension().map(|ext| ext == "tgz").unwrap_or(false) {
+                    let filename = path
+                        .file_name()
+                        .ok_or_else(|| anyhow::anyhow!("Chart archive has no filename"))?;
+                    file_paths.push(charts_dir.join(filename));
+                }
+                Ok(())
+            })?;
+        }
+        Ok(file_paths)
+    }
+}
+
+impl Dependent for HelmDependent {
+    fn update_version(
+        &self,
+        version: &Version,
+        options: &super::DependentUpdateOptions,
+    ) -> Result<Vec<PathBuf>> {
+        let selector = self
+            .settings
+            .selector
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("Selector is required for Helm dependent"))?;
+        let chart_dir = &self.settings.dependent_path;
+        let chart_yaml_path = chart_dir.join("Chart.yaml");
+        let file_content = crate::io::read_file(&chart_yaml_path, &self.repo_path)?;
+        let new_file_content =
+            crate::edit::yaml::edit(&file_content, &selector, &version.to_string())?;
+        crate::io::write_file(&chart_yaml_path, &self.repo_path, new_file_content.as_str())?;
+        let mut file_paths = vec![chart_yaml_path.clone()];
+        if options.helm_dependency_update {
+            self.run_helm_dependency_update(&self.repo_path.join(chart_dir))?;
+            file_paths.extend(self.collect_dependency_artifacts(chart_dir)?);
+        }
+        Ok(file_paths)
+    }
+}

--- a/src/dependents/mod.rs
+++ b/src/dependents/mod.rs
@@ -4,6 +4,7 @@ use std::{fmt::Debug, path::PathBuf};
 use crate::{settings::DependentSettings, version::Version};
 use serde::Deserialize;
 
+mod helm;
 mod regex;
 mod toml;
 mod yaml;
@@ -11,6 +12,7 @@ mod yaml;
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum DependentType {
+    Helm,
     Regex,
     Toml,
     Yaml,
@@ -21,6 +23,10 @@ pub fn get_dependent(
     repo_path: PathBuf,
 ) -> Result<Box<dyn Dependent>> {
     match dependent_settings.dependent_type {
+        DependentType::Helm => Ok(Box::new(helm::HelmDependent {
+            settings: dependent_settings.clone(),
+            repo_path,
+        })),
         DependentType::Regex => Ok(Box::new(regex::RegexDependent {
             settings: dependent_settings.clone(),
             repo_path,
@@ -37,6 +43,15 @@ pub fn get_dependent(
 }
 
 pub trait Dependent: Debug {
-    fn update_version(&self, version: &Version) -> Result<()>;
-    fn get_file_path(&self) -> PathBuf;
+    /// Update the dependent and return the list of files it modified.
+    fn update_version(
+        &self,
+        version: &Version,
+        options: &DependentUpdateOptions,
+    ) -> Result<Vec<PathBuf>>;
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DependentUpdateOptions {
+    pub helm_dependency_update: bool,
 }

--- a/src/dependents/regex.rs
+++ b/src/dependents/regex.rs
@@ -13,7 +13,11 @@ pub struct RegexDependent {
 }
 
 impl Dependent for RegexDependent {
-    fn update_version(&self, version: &Version) -> Result<()> {
+    fn update_version(
+        &self,
+        version: &Version,
+        _options: &super::DependentUpdateOptions,
+    ) -> Result<Vec<PathBuf>> {
         let file_content = crate::io::read_file(&self.settings.dependent_path, &self.repo_path)?;
         let new_file_content = update_regex(&file_content, version, &self.settings)?;
         crate::io::write_file(
@@ -21,11 +25,7 @@ impl Dependent for RegexDependent {
             &self.repo_path,
             new_file_content.as_str(),
         )?;
-        Ok(())
-    }
-
-    fn get_file_path(&self) -> PathBuf {
-        self.settings.dependent_path.clone()
+        Ok(vec![self.settings.dependent_path.clone()])
     }
 }
 

--- a/src/dependents/toml.rs
+++ b/src/dependents/toml.rs
@@ -13,7 +13,11 @@ pub struct TomlDependent {
 }
 
 impl Dependent for TomlDependent {
-    fn update_version(&self, version: &Version) -> Result<()> {
+    fn update_version(
+        &self,
+        version: &Version,
+        _options: &super::DependentUpdateOptions,
+    ) -> Result<Vec<PathBuf>> {
         let file_path = &self.settings.dependent_path;
         let repo_path = &self.repo_path;
         let selector = self
@@ -25,10 +29,6 @@ impl Dependent for TomlDependent {
         let new_file_content =
             crate::edit::toml::edit(&file_content, &selector, &version.to_string())?;
         crate::io::write_file(file_path, repo_path, new_file_content.as_str())?;
-        Ok(())
-    }
-
-    fn get_file_path(&self) -> PathBuf {
-        self.settings.dependent_path.clone()
+        Ok(vec![self.settings.dependent_path.clone()])
     }
 }

--- a/src/dependents/yaml.rs
+++ b/src/dependents/yaml.rs
@@ -13,7 +13,11 @@ pub struct YamlDepedent {
 }
 
 impl Dependent for YamlDepedent {
-    fn update_version(&self, version: &Version) -> Result<()> {
+    fn update_version(
+        &self,
+        version: &Version,
+        _options: &super::DependentUpdateOptions,
+    ) -> Result<Vec<PathBuf>> {
         let file_path = &self.settings.dependent_path;
         let repo_path = &self.repo_path;
         let selector = self
@@ -25,10 +29,6 @@ impl Dependent for YamlDepedent {
         let new_file_content =
             crate::edit::yaml::edit(&file_content, &selector, &version.to_string())?;
         crate::io::write_file(file_path, repo_path, new_file_content.as_str())?;
-        Ok(())
-    }
-
-    fn get_file_path(&self) -> PathBuf {
-        self.settings.dependent_path.clone()
+        Ok(vec![self.settings.dependent_path.clone()])
     }
 }

--- a/src/edit/yaml.rs
+++ b/src/edit/yaml.rs
@@ -1,7 +1,20 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use libyaml_safer::{Document, Node, NodeData, NodePair, Parser, ScalarStyle};
 
 use super::LineContext;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SelectorFilter {
+    Index(usize),
+    KeyValue { key: String, value: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SelectorPart {
+    key: String,
+    filter: Option<SelectorFilter>,
+    raw: String,
+}
 
 /// Edit a YAML file for a given selector
 pub fn edit(file_content: &str, selector: &str, new_value: &str) -> Result<String> {
@@ -60,15 +73,18 @@ fn load_document(file_content: &str) -> Result<Document> {
 /// corresponds to the given selector.
 fn get_value_node<'a>(document: &'a mut Document, selector: &str) -> Result<&'a Node> {
     // Split the selector into keys
-    let keys = selector.split('.').collect::<Vec<_>>();
+    let parts = selector
+        .split('.')
+        .map(parse_selector_part)
+        .collect::<Result<Vec<_>>>()?;
     // Start at the root node
     let mut current_node = document
         .get_node(1)
         .ok_or_else(|| anyhow::anyhow!("YAML document does not contain a root node"))?;
     // Keep track of the keys we've processed so far for error messages
     let mut processed_keys = Vec::new();
-    for key in keys {
-        processed_keys.push(key);
+    for part in parts {
+        processed_keys.push(part.raw.clone());
         // Get the node pairs for the current mapping
         let pairs = match &current_node.data {
             NodeData::Mapping { pairs, .. } => pairs,
@@ -80,13 +96,42 @@ fn get_value_node<'a>(document: &'a mut Document, selector: &str) -> Result<&'a 
             }
         };
         // Find the pair that corresponds to the current key
-        if let Some(pair) = find_node_pair_by_key(document, pairs, key) {
-            current_node = document.get_node(pair.value).unwrap();
-        } else {
-            return Err(anyhow::anyhow!(
-                "Key '{}' not found or not scalar",
-                processed_keys.join(".")
-            ));
+        let pair = find_node_pair_by_key(document, pairs, &part.key).with_context(|| {
+            format!("Key '{}' not found or not scalar", processed_keys.join("."))
+        })?;
+        current_node = document.get_node(pair.value).unwrap();
+        // If there's a filter, apply it
+        if let Some(filter) = part.filter {
+            let NodeData::Sequence { items, .. } = &current_node.data else {
+                return Err(anyhow::anyhow!(
+                    "Value for '{}' is not a sequence",
+                    processed_keys.join(".")
+                ));
+            };
+            let next_node = match filter {
+                // Return the item at the given index
+                SelectorFilter::Index(index) => {
+                    items.get(index).and_then(|item| document.get_node(*item))
+                }
+                // Find the first item where the given key has the given value
+                SelectorFilter::KeyValue { key, value } => items.iter().find_map(|item| {
+                    let node = document.get_node(*item)?;
+                    if let NodeData::Mapping { pairs, .. } = &node.data {
+                        let pair = find_node_pair_by_key(document, pairs, &key)?;
+                        let value_node = document.get_node(pair.value)?;
+                        matches!(
+                            &value_node.data,
+                            NodeData::Scalar { value: scalar, .. } if scalar == &value
+                        )
+                        .then_some(node)
+                    } else {
+                        None
+                    }
+                }),
+            };
+            current_node = next_node.ok_or_else(|| {
+                anyhow::anyhow!("Key '{}' not found or not scalar", processed_keys.join("."))
+            })?;
         }
     }
     // Return the node for the final key, which should be a scalar
@@ -115,6 +160,73 @@ fn find_node_pair_by_key<'a>(
             NodeData::Scalar { value, .. } => value == key,
             _ => false,
         })
+}
+
+fn parse_selector_part(raw: &str) -> Result<SelectorPart> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err(anyhow::anyhow!("Selector contains an empty segment"));
+    }
+    if let Some(start) = raw.find('[') {
+        if !raw.ends_with(']') {
+            return Err(anyhow::anyhow!("Selector segment '{}' is missing ']'", raw));
+        }
+        let key = raw[..start].trim();
+        if key.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Selector segment '{}' is missing a key",
+                raw
+            ));
+        }
+        let inner = &raw[start + 1..raw.len() - 1];
+        let filter = match inner.split_once('=') {
+            Some((filter_key, filter_value)) => {
+                let filter_key = filter_key.trim();
+                let filter_value = unquote(filter_value.trim());
+                anyhow::ensure!(
+                    !filter_value.is_empty(),
+                    "Selector segment '{}' has an empty filter value",
+                    raw
+                );
+                anyhow::ensure!(
+                    !filter_key.is_empty(),
+                    "Selector segment '{}' has an empty filter key",
+                    raw
+                );
+                SelectorFilter::KeyValue {
+                    key: filter_key.to_string(),
+                    value: filter_value,
+                }
+            }
+            None => {
+                let index: usize = inner.trim().parse().map_err(|_| {
+                    anyhow::anyhow!("Selector segment '{}' has an invalid index", raw)
+                })?;
+                SelectorFilter::Index(index)
+            }
+        };
+        Ok(SelectorPart {
+            key: key.to_string(),
+            filter: Some(filter),
+            raw: raw.to_string(),
+        })
+    } else {
+        Ok(SelectorPart {
+            key: raw.to_string(),
+            filter: None,
+            raw: raw.to_string(),
+        })
+    }
+}
+
+fn unquote(value: &str) -> String {
+    let mut unquoted = value.to_string();
+    if (unquoted.starts_with('"') && unquoted.ends_with('"'))
+        || (unquoted.starts_with('\'') && unquoted.ends_with('\''))
+    {
+        unquoted = unquoted[1..unquoted.len() - 1].to_string();
+    }
+    unquoted
 }
 
 #[cfg(test)]
@@ -172,12 +284,155 @@ dependencies:
     fn test_query_nested() {
         let file_content = r#"single_key: "single_value"
 test_key:
-  nested_key: "value"     
+  nested_key: "value"
 dependencies:
   serde: "1.0""#;
         let selector = "dependencies.serde";
         let result = query(file_content, selector).unwrap();
         assert_eq!(result.value, "1.0");
+        assert_eq!(result.line_number, 5);
+    }
+
+    #[test]
+    fn test_query_sequence_index() {
+        let file_content = r#"dependencies:
+  - name: common
+    version: "1.0.0"
+  - name: other
+    version: "2.0.0""#;
+        let selector = "dependencies[0].version";
+        let result = query(file_content, selector).unwrap();
+        assert_eq!(result.value, "1.0.0");
+        assert_eq!(result.line_number, 3);
+    }
+
+    #[test]
+    fn test_query_sequence_index_scalar_item() {
+        let file_content = r#"dependencies:
+  - "alpha"
+  - "beta""#;
+        let selector = "dependencies[0]";
+        let result = query(file_content, selector).unwrap();
+        assert_eq!(result.value, "alpha");
+        assert_eq!(result.line_number, 2);
+    }
+
+    #[test]
+    fn test_query_sequence_index_out_of_range() {
+        let file_content = r#"dependencies:
+  - name: common
+    version: "1.0.0""#;
+        let selector = "dependencies[2].version";
+        let result = query(file_content, selector);
+        match result {
+            Ok(_) => panic!("Expected an error"),
+            Err(e) => assert!(e.to_string().contains("Key 'dependencies[2]' not found")),
+        }
+    }
+
+    #[test]
+    fn test_query_filter_on_non_sequence() {
+        let file_content = r#"dependencies:
+  name: common
+  version: "1.0.0""#;
+        let selector = "dependencies[name=common].version";
+        let result = query(file_content, selector);
+        match result {
+            Ok(_) => panic!("Expected an error"),
+            Err(e) => assert!(e
+                .to_string()
+                .contains("Value for 'dependencies[name=common]' is not a sequence")),
+        }
+    }
+
+    #[test]
+    fn test_query_filter_key_missing_in_item() {
+        let file_content = r#"dependencies:
+  - version: "1.0.0""#;
+        let selector = "dependencies[name=common].version";
+        let result = query(file_content, selector);
+        match result {
+            Ok(_) => panic!("Expected an error"),
+            Err(e) => assert!(e
+                .to_string()
+                .contains("Key 'dependencies[name=common]' not found")),
+        }
+    }
+
+    #[test]
+    fn test_query_invalid_index_format() {
+        let file_content = r#"dependencies:
+  - name: common
+    version: "1.0.0""#;
+        let selector = "dependencies[abc].version";
+        let result = query(file_content, selector);
+        match result {
+            Ok(_) => panic!("Expected an error"),
+            Err(e) => assert!(e
+                .to_string()
+                .contains("Selector segment 'dependencies[abc]' has an invalid index")),
+        }
+    }
+
+    #[test]
+    fn test_query_missing_closing_bracket() {
+        let file_content = r#"dependencies:
+  - name: common
+    version: "1.0.0""#;
+        let selector = "dependencies[0.version";
+        let result = query(file_content, selector);
+        match result {
+            Ok(_) => panic!("Expected an error"),
+            Err(e) => assert!(e
+                .to_string()
+                .contains("Selector segment 'dependencies[0' is missing ']'")),
+        }
+    }
+
+    #[test]
+    fn test_query_sequence_filter() {
+        let file_content = r#"dependencies:
+  - name: common
+    version: "1.0.0"
+  - name: other
+    version: "2.0.0""#;
+        let selector = "dependencies[name=common].version";
+        let result = query(file_content, selector).unwrap();
+        assert_eq!(result.value, "1.0.0");
+        assert_eq!(result.line_number, 3);
+    }
+
+    #[test]
+    fn test_edit_sequence_filter() {
+        let file_content = r#"dependencies:
+  - name: common
+    version: "1.0.0"
+  - name: other
+    version: "2.0.0""#;
+        let selector = "dependencies[name=other].version";
+        let result = edit(file_content, selector, "2.1.0").unwrap();
+        assert_eq!(
+            result,
+            r#"dependencies:
+  - name: common
+    version: "1.0.0"
+  - name: other
+    version: "2.1.0""#
+        );
+    }
+
+    #[test]
+    fn test_query_nested_sequence_filter() {
+        let file_content = r#"groups:
+  - name: app
+    dependencies:
+      - name: common
+        version: "1.0.0"
+      - name: other
+        version: "2.0.0""#;
+        let selector = "groups[name=app].dependencies[name=common].version";
+        let result = query(file_content, selector).unwrap();
+        assert_eq!(result.value, "1.0.0");
         assert_eq!(result.line_number, 5);
     }
 


### PR DESCRIPTION
Implement Helm as a dependent. This means that Helm chart dependencies can now be managed using the following monoverse configuration.

```yaml
projects:
  common:
    type: yaml
    path: charts/common
    manifest_path: charts/common/Chart.yaml
    selector: version
    dependents:
      - type: helm
        path: charts/app
        selector: dependencies[name=common].version
  app:
    type: helm
    path: charts/app
```

In this case the `common` chart is a library chart. Therefore, the `yaml` project type with `version` as the selector is used here. When the `common` chart is released using `monoverse`, the dependencies section will also be updated with the new version. The added `--helm-dependency-update` command line option runs `helm depedency update` against the dependent chart.

The dependent Chart.yaml could look like this:

```yaml
apiVersion: v2
name: app
description: App Helm chart
type: application
version: 0.1.0
appVersion: "25.12.2"

dependencies:
  - name: common
    version: "25.12.0"
    repository: "file://../common"
```

This also adds sequence selectors to standard YAML projects. Now we can index lists or choose items based on a key-value match (first occurrence). Examples: `dependencies[0].version` or `dependencies[name=common].version`. Index based selection can also be used for lists with scalar items (`dependencies[0]` is a valid selector if the selected value is scalar).
